### PR TITLE
Remove openstack.NewSession error result

### DIFF
--- a/examples/10-objectstore.go
+++ b/examples/10-objectstore.go
@@ -54,11 +54,7 @@ func main() {
 	}
 
 	// Make a new client with these creds
-	sess, err := openstack.NewSession(nil, auth, nil)
-	if err != nil {
-		panicString := fmt.Sprint("Error crating new Session:", err)
-		panic(panicString)
-	}
+	sess := openstack.NewSession(nil, auth, nil)
 
 	hdr, err := objectstorage.GetAccountMeta(sess, url)
 	if err != nil {

--- a/examples/30-image-v1.go
+++ b/examples/30-image-v1.go
@@ -50,11 +50,7 @@ func main() {
 	}
 
 	// Make a new client with these creds
-	sess, err := openstack.NewSession(nil, auth, nil)
-	if err != nil {
-		panicString := fmt.Sprint("Error crating new Session:", err)
-		panic(panicString)
-	}
+	sess := openstack.NewSession(nil, auth, nil)
 
 	imageService := image.Service{
 		Session: *sess,

--- a/identity/middleware/validation.go
+++ b/identity/middleware/validation.go
@@ -336,9 +336,6 @@ func (validator *Validator) renewToken() error {
 	}
 
 	// Make a new client with these creds
-	serviceTokenSession, err = openstack.NewSession(nil, auth, nil)
-	if err != nil {
-		return err
-	}
+	serviceTokenSession = openstack.NewSession(nil, auth, nil)
 	return nil
 }

--- a/image/v1/image_test.go
+++ b/image/v1/image_test.go
@@ -167,7 +167,7 @@ func testImageServiceAction(t *testing.T, uriEndsWith string, testData string, i
 			},
 		},
 	}
-	sess, _ := openstack.NewSession(http.DefaultClient, auth, nil)
+	sess := openstack.NewSession(http.DefaultClient, auth, nil)
 	imageService := image.Service{
 		Session: *sess,
 		URL:     apiServer.URL,

--- a/openstack/session.go
+++ b/openstack/session.go
@@ -46,7 +46,8 @@ type Session struct {
 	Headers    http.Header
 }
 
-func NewSession(hclient *http.Client, auth AuthRef, tls *tls.Config) (session *Session, err error) {
+// NewSession return new Session instance
+func NewSession(hclient *http.Client, auth AuthRef, tls *tls.Config) *Session {
 	if hclient == nil {
 		// Only build a transport if we're also building the client
 		tr := &http.Transport{
@@ -55,12 +56,11 @@ func NewSession(hclient *http.Client, auth AuthRef, tls *tls.Config) (session *S
 		}
 		hclient = &http.Client{Transport: tr}
 	}
-	session = &Session{
+	return &Session{
 		httpClient: hclient,
 		AuthToken:  auth,
 		Headers:    http.Header{},
 	}
-	return session, nil
 }
 
 func (s *Session) NewRequest(method, url string, headers *http.Header, body io.Reader) (req *http.Request, err error) {
@@ -241,7 +241,7 @@ func Delete(
 	params *url.Values,
 	headers *http.Header,
 ) (resp *http.Response, err error) {
-	s, _ := NewSession(nil, nil, nil)
+	s := NewSession(nil, nil, nil)
 	return s.Delete(url, params, headers)
 }
 
@@ -251,7 +251,7 @@ func Get(
 	params *url.Values,
 	headers *http.Header,
 ) (resp *http.Response, err error) {
-	s, _ := NewSession(nil, nil, nil)
+	s := NewSession(nil, nil, nil)
 	return s.Get(url, params, headers)
 }
 
@@ -262,7 +262,7 @@ func GetJSON(
 	headers *http.Header,
 	responseContainer interface{},
 ) (resp *http.Response, err error) {
-	s, _ := NewSession(nil, nil, nil)
+	s := NewSession(nil, nil, nil)
 	return s.RequestJSON("GET", url, params, headers, nil, responseContainer)
 }
 
@@ -273,7 +273,7 @@ func Post(
 	headers *http.Header,
 	body *[]byte,
 ) (resp *http.Response, err error) {
-	s, _ := NewSession(nil, nil, nil)
+	s := NewSession(nil, nil, nil)
 	return s.Post(url, params, headers, body)
 }
 
@@ -285,7 +285,7 @@ func PostJSON(
 	body interface{},
 	responseContainer interface{},
 ) (resp *http.Response, err error) {
-	s, _ := NewSession(nil, nil, nil)
+	s := NewSession(nil, nil, nil)
 	return s.RequestJSON("POST", url, params, headers, body, responseContainer)
 }
 
@@ -296,6 +296,6 @@ func Put(
 	headers *http.Header,
 	body *[]byte,
 ) (resp *http.Response, err error) {
-	s, _ := NewSession(nil, nil, nil)
+	s := NewSession(nil, nil, nil)
 	return s.Put(url, params, headers, body)
 }

--- a/openstack/session_test.go
+++ b/openstack/session_test.go
@@ -41,7 +41,7 @@ func TestSessionGet(t *testing.T) {
 	expected := TestStruct{ID: "id1", Name: "Chris"}
 	actual := TestStruct{}
 
-	s, _ := openstack.NewSession(nil, nil, nil)
+	s := openstack.NewSession(nil, nil, nil)
 	var headers http.Header = http.Header{}
 	headers.Set("X-Auth-Token", tokn)
 	headers.Set("Accept", "application/json")


### PR DESCRIPTION
Hi!
Now `openstack.NewSession` never return `error`, maybe it's legacy code or tab for the future, but what about remove return `error`? 
Thanks.